### PR TITLE
Fix Windows CI build warnings

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Pre-commit hook: check formatting and lints before committing.
+
+set -e
+
+# Check cargo fmt
+if ! cargo fmt --all -- --check 2>/dev/null; then
+    echo "ERROR: cargo fmt check failed. Run 'cargo fmt --all' to fix."
+    exit 1
+fi
+
+# Check clippy (default features only — cross-platform gated code checked in CI)
+if ! cargo clippy -- -D warnings 2>/dev/null; then
+    echo "ERROR: cargo clippy found warnings. Fix them before committing."
+    exit 1
+fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ### Fixed
 - **Depth feature** — `depth` feature now depends on `webcam` (depth estimation requires webcam input), eliminating dead-code warnings when building with `--features depth` alone
+- **Windows CI warnings** — removed unused import, allowed dead code on `wasapi_available()`, fixed unreachable expression in `create_audio_fifo()`, fixed function pointer cast in midir patch
+
+### Added
+- **Pre-commit hook** — `.githooks/pre-commit` runs `cargo fmt --check` and `cargo clippy -D warnings`
 
 ### Changed
 - **README** — expanded build-from-source section with per-feature prerequisites; added Binding Matrix section and `B` keyboard shortcut

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,11 @@ Thanks for your interest in contributing! Phosphor is a live VJ engine built wit
 - Audio input device (built-in mic works)
 - Vulkan-capable GPU
 
+**Setup:**
+```bash
+git config core.hooksPath .githooks   # enable pre-commit checks (fmt + clippy)
+```
+
 **Commands:**
 ```bash
 cargo run --release              # release build (recommended)

--- a/crates/phosphor-app/src/audio/wasapi_capture.rs
+++ b/crates/phosphor-app/src/audio/wasapi_capture.rs
@@ -7,6 +7,7 @@ use std::sync::{Arc, OnceLock};
 use std::thread;
 use std::time::Duration;
 
+use super::capture::RingBuffer;
 use anyhow::Result;
 use windows::Win32::Media::Audio::{
     AUDCLNT_SHAREMODE_SHARED, AUDCLNT_STREAMFLAGS_LOOPBACK, IAudioCaptureClient, IAudioClient,
@@ -19,7 +20,6 @@ use windows::Win32::System::Com::{
     CoUninitialize, STGM_READ,
 };
 use windows::Win32::UI::Shell::PropertiesSystem::IPropertyStore;
-use super::capture::RingBuffer;
 
 /// Check if WASAPI loopback is available at runtime. Cached.
 #[allow(dead_code)]

--- a/crates/phosphor-app/src/audio/wasapi_capture.rs
+++ b/crates/phosphor-app/src/audio/wasapi_capture.rs
@@ -19,11 +19,10 @@ use windows::Win32::System::Com::{
     CoUninitialize, STGM_READ,
 };
 use windows::Win32::UI::Shell::PropertiesSystem::IPropertyStore;
-use windows::core::Interface;
-
 use super::capture::RingBuffer;
 
 /// Check if WASAPI loopback is available at runtime. Cached.
+#[allow(dead_code)]
 pub fn wasapi_available() -> bool {
     static AVAILABLE: OnceLock<bool> = OnceLock::new();
     // SAFETY: COM APIs are FFI calls. CoInitializeEx/CoCreateInstance are safe to call

--- a/crates/phosphor-app/src/recording/encoder.rs
+++ b/crates/phosphor-app/src/recording/encoder.rs
@@ -208,14 +208,13 @@ pub fn create_audio_fifo() -> Result<PathBuf, String> {
         if !status.success() {
             return Err("mkfifo returned non-zero".to_string());
         }
+        Ok(path)
     }
 
     #[cfg(not(unix))]
     {
-        return Err("Audio recording via FIFO not supported on this platform".to_string());
+        Err("Audio recording via FIFO not supported on this platform".to_string())
     }
-
-    Ok(path)
 }
 
 /// Spawn the ffmpeg encoder subprocess.

--- a/patches/midir/src/backend/winmm/mod.rs
+++ b/patches/midir/src/backend/winmm/mod.rs
@@ -248,7 +248,7 @@ impl MidiInput {
             midiInOpen(
                 in_handle.as_mut_ptr(),
                 port_number as UINT,
-                handler::handle_input::<T> as DWORD_PTR,
+                handler::handle_input::<T> as *const () as DWORD_PTR,
                 handler_data_ptr as DWORD_PTR,
                 CALLBACK_FUNCTION,
             )


### PR DESCRIPTION
## Summary
- Remove unused `windows::core::Interface` import in wasapi_capture.rs
- Add `#[allow(dead_code)]` on `wasapi_available()` (kept for future use)
- Restructure cfg blocks in `create_audio_fifo()` to eliminate unreachable expression warning
- Use two-step function pointer cast in midir winmm patch (compiler suggestion)

## Test plan
- [ ] Windows CI build passes with no warnings in phosphor code or midir patch
- [ ] Linux `cargo check` passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)