### PR TITLE
Fix Windows CI warnings, add pre-commit hook, and clean up clippy/docs

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Pre-commit hook: check formatting and lints before committing.
+
+set -e
+
+# Check cargo fmt
+if ! cargo fmt --all -- --check 2>/dev/null; then
+    echo "ERROR: cargo fmt check failed. Run 'cargo fmt --all' to fix."
+    exit 1
+fi
+
+# Check clippy (default features only — cross-platform gated code checked in CI)
+if ! cargo clippy -- -D warnings 2>/dev/null; then
+    echo "ERROR: cargo clippy found warnings. Fix them before committing."
+    exit 1
+fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ### Fixed
 - **Depth feature** — `depth` feature now depends on `webcam` (depth estimation requires webcam input), eliminating dead-code warnings when building with `--features depth` alone
+- **Windows CI warnings** — removed unused import, allowed dead code on `wasapi_available()`, fixed unreachable expression in `create_audio_fifo()`, fixed function pointer cast in midir patch
+
+### Added
+- **Pre-commit hook** — `.githooks/pre-commit` runs `cargo fmt --check` and `cargo clippy -D warnings`
 
 ### Changed
 - **README** — expanded build-from-source section with per-feature prerequisites; added Binding Matrix section and `B` keyboard shortcut

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ## Unreleased
 
 ### Fixed
+- **Clippy warnings** — cleared 13 default-feature clippy lints (collapsible match guards in `app.rs`/`main.rs`/`web/state.rs`, derivable `Default` for `ParticleQuality`, redundant `String` clones in UI panels)
 - **Depth feature** — `depth` feature now depends on `webcam` (depth estimation requires webcam input), eliminating dead-code warnings when building with `--features depth` alone
 - **Windows CI warnings** — removed unused import, allowed dead code on `wasapi_available()`, fixed unreachable expression in `create_audio_fifo()`, fixed function pointer cast in midir patch
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 
 ## Unreleased
 
+### Security
+- **Dependency advisories** — bumped `rustls-webpki` 0.103.9 → 0.103.13 (RUSTSEC-2026-0049, RUSTSEC-2026-0098) and `tar` 0.4.44 → 0.4.46 (RUSTSEC-2026-0067, RUSTSEC-2026-0068) to clear the cargo-deny audit
+
 ### Fixed
 - **Clippy warnings** — cleared 13 default-feature clippy lints (collapsible match guards in `app.rs`/`main.rs`/`web/state.rs`, derivable `Default` for `ParticleQuality`, redundant `String` clones in UI panels)
 - **Depth feature** — `depth` feature now depends on `webcam` (depth estimation requires webcam input), eliminating dead-code warnings when building with `--features depth` alone

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Changed
 - **README** — expanded build-from-source section with per-feature prerequisites; added Binding Matrix section and `B` keyboard shortcut
+- **NDI docs** — clarified that NDI output is built into official release downloads (only the NDI runtime needs installing); the `--features ndi` flag now framed as a from-source-only step in README and TUTORIALS
 
 ## v1.7.1 — 2026-03-12
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,11 @@ Thanks for your interest in contributing! Phosphor is a live VJ engine built wit
 - Audio input device (built-in mic works)
 - Vulkan-capable GPU
 
+**Setup:**
+```bash
+git config core.hooksPath .githooks   # enable pre-commit checks (fmt + clippy)
+```
+
 **Commands:**
 ```bash
 cargo run --release              # release build (recommended)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -157,7 +157,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1135,7 +1135,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1381,7 +1381,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3282,7 +3282,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phosphor-app"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3802,7 +3802,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3831,9 +3831,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4170,9 +4170,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -4189,7 +4189,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4445,7 +4445,7 @@ checksum = "51b70b87d15e91f553711b40df3048faf27a7a04e01e0ddc0cf9309f0af7c2ca"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5098,7 +5098,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 | **Effects** | 23 built-in effects (particle sims, feedback shaders, reaction-diffusion, flocking, strange attractors, morphing) |
 | **Compositing** | 8-layer stack · 10 blend modes · Media layers (GIF/PNG/MP4) · Webcam layers · Monocular depth (MiDaS) |
 | **Control** | Binding matrix (flow editor) · MIDI learn + auto-connect · OSC in/out with learn · Web touch surface (phone/tablet) |
-| **Output** | NDI® (`--features ndi`, runtime-loaded) · Presets · Scene cues with timeline morphing |
+| **Output** | NDI® (built in, runtime-loaded) · Presets · Scene cues with timeline morphing |
 
 ## Note from Dev
 
@@ -43,6 +43,8 @@ Grab the latest release for your platform from [**GitHub Releases**](https://git
 - **macOS** — download the `.dmg`, open it, drag Phosphor to Applications (signed & notarized)
 - **Windows** — download the `.zip`, extract, run `phosphor.exe`
 - **Linux** — download the `.tar.gz`, extract, run `./phosphor`
+
+NDI® output is built into the official downloads — to use it, install the [NDI® runtime](https://ndi.video) (the only extra step needed).
 
 <details>
 <summary><strong>Build from source</strong></summary>

--- a/TUTORIALS.md
+++ b/TUTORIALS.md
@@ -781,8 +781,9 @@ Multiple devices can connect simultaneously. All clients receive real-time state
 NDI (Network Device Interface) lets you send Phosphor's output to other software over the network — OBS, vMix, Resolume, TouchDesigner, and any NDI-compatible receiver.
 
 **Requirements:**
-- Build with `cargo run --features ndi`
-- Install NDI runtime from [ndi.video](https://ndi.video)
+- **Official release downloads** (macOS/Windows/Linux): NDI is already built in — you only need the NDI runtime.
+- **Building from source:** add `--features ndi` (e.g. `cargo run --release --features ndi`).
+- Install the NDI runtime from [ndi.video](https://ndi.video). Phosphor loads it dynamically at startup; if it's missing, the NDI panel lists the locations it searched and a download link.
 
 **Setup:**
 1. Open the **Outputs** section in the left sidebar

--- a/crates/phosphor-app/src/app.rs
+++ b/crates/phosphor-app/src/app.rs
@@ -1742,7 +1742,7 @@ impl App {
                     let path = self.effect_loader.resolve_shader_path(&pass.shader);
                     if let Ok(content) = std::fs::read_to_string(&path) {
                         self.shader_editor.open_file(&effect.name, path, content);
-                        self.shader_editor.compile_error = Some(e.to_string());
+                        self.shader_editor.compile_error = Some(e.clone());
                         // Load paired .pfx for tab switching
                         if let Some(ref pfx_path) = effect.source_path {
                             if let Ok(pfx_content) = std::fs::read_to_string(pfx_path) {
@@ -2117,15 +2117,14 @@ impl App {
                     }
                 }
             }
-            "global" => {
+            "global"
                 // global.master_opacity
-                if rest == "master_opacity" {
+                if rest == "master_opacity" => {
                     let clamped = value.clamp(0.0, 1.0);
                     for layer in &mut self.layer_stack.layers {
                         layer.opacity = clamped;
                     }
                 }
-            }
             "scene" => {
                 // scene.transport.go / scene.transport.prev / scene.transport.stop
                 if let Some(action) = rest.strip_prefix("transport.") {
@@ -2135,9 +2134,9 @@ impl App {
                     }
                 }
             }
-            "postfx" => {
+            "postfx"
                 // postfx.bloom_threshold, postfx.bloom_intensity, etc.
-                if !rest.is_empty() {
+                if !rest.is_empty() => {
                     if let Some(layer) = self.layer_stack.active_mut() {
                         match rest {
                             "bloom_threshold" => {
@@ -2159,10 +2158,9 @@ impl App {
                         }
                     }
                 }
-            }
-            "particle" => {
+            "particle"
                 // particle.{setting_name} — applies to all layers' particle systems
-                if !rest.is_empty() {
+                if !rest.is_empty() => {
                     let v = value.clamp(0.0, 1.0);
                     for layer in &mut self.layer_stack.layers {
                         if let Some(effect) = layer.as_effect_mut() {
@@ -2200,10 +2198,9 @@ impl App {
                         }
                     }
                 }
-            }
-            "uniform" => {
+            "uniform"
                 // Direct shader uniform override: uniform.{field_name}
-                if !rest.is_empty() {
+                if !rest.is_empty() => {
                     let v = value.clamp(0.0, 1.0);
                     match rest {
                         "sub_bass" => self.uniforms.sub_bass = v,
@@ -2232,7 +2229,6 @@ impl App {
                         _ => {}
                     }
                 }
-            }
             _ => {}
         }
     }

--- a/crates/phosphor-app/src/audio/wasapi_capture.rs
+++ b/crates/phosphor-app/src/audio/wasapi_capture.rs
@@ -7,6 +7,7 @@ use std::sync::{Arc, OnceLock};
 use std::thread;
 use std::time::Duration;
 
+use super::capture::RingBuffer;
 use anyhow::Result;
 use windows::Win32::Media::Audio::{
     AUDCLNT_SHAREMODE_SHARED, AUDCLNT_STREAMFLAGS_LOOPBACK, IAudioCaptureClient, IAudioClient,
@@ -19,7 +20,6 @@ use windows::Win32::System::Com::{
     CoUninitialize, STGM_READ,
 };
 use windows::Win32::UI::Shell::PropertiesSystem::IPropertyStore;
-use super::capture::RingBuffer;
 
 /// Check if WASAPI loopback is available at runtime. Cached.
 #[allow(dead_code)]

--- a/crates/phosphor-app/src/audio/wasapi_capture.rs
+++ b/crates/phosphor-app/src/audio/wasapi_capture.rs
@@ -19,11 +19,10 @@ use windows::Win32::System::Com::{
     CoUninitialize, STGM_READ,
 };
 use windows::Win32::UI::Shell::PropertiesSystem::IPropertyStore;
-use windows::core::Interface;
-
 use super::capture::RingBuffer;
 
 /// Check if WASAPI loopback is available at runtime. Cached.
+#[allow(dead_code)]
 pub fn wasapi_available() -> bool {
     static AVAILABLE: OnceLock<bool> = OnceLock::new();
     // SAFETY: COM APIs are FFI calls. CoInitializeEx/CoCreateInstance are safe to call

--- a/crates/phosphor-app/src/main.rs
+++ b/crates/phosphor-app/src/main.rs
@@ -158,27 +158,24 @@ impl ApplicationHandler for PhosphorApp {
                     KeyCode::KeyD => {
                         app.egui_overlay.toggle_visible();
                     }
-                    KeyCode::Space => {
+                    KeyCode::Space
                         // Scene: go to next cue (when timeline has cues)
-                        if !app.timeline.cues.is_empty() {
+                        if !app.timeline.cues.is_empty() => {
                             app.egui_overlay.context().data_mut(|d| {
                                 d.insert_temp(egui::Id::new("scene_go_next"), true);
                             });
                         }
-                    }
-                    KeyCode::KeyT => {
+                    KeyCode::KeyT
                         // Toggle timeline active (when cues loaded)
-                        if !app.timeline.cues.is_empty() {
+                        if !app.timeline.cues.is_empty() => {
                             app.egui_overlay.context().data_mut(|d| {
                                 d.insert_temp(egui::Id::new("scene_toggle_play"), true);
                             });
                         }
-                    }
-                    KeyCode::KeyB => {
-                        if !app.shader_editor.open {
+                    KeyCode::KeyB
+                        if !app.shader_editor.open => {
                             app.binding_matrix.open = !app.binding_matrix.open;
                         }
-                    }
                     KeyCode::BracketLeft => {
                         // Previous layer
                         let num = app.layer_stack.layers.len();

--- a/crates/phosphor-app/src/recording/encoder.rs
+++ b/crates/phosphor-app/src/recording/encoder.rs
@@ -208,14 +208,13 @@ pub fn create_audio_fifo() -> Result<PathBuf, String> {
         if !status.success() {
             return Err("mkfifo returned non-zero".to_string());
         }
+        Ok(path)
     }
 
     #[cfg(not(unix))]
     {
-        return Err("Audio recording via FIFO not supported on this platform".to_string());
+        Err("Audio recording via FIFO not supported on this platform".to_string())
     }
-
-    Ok(path)
 }
 
 /// Spawn the ffmpeg encoder subprocess.

--- a/crates/phosphor-app/src/settings.rs
+++ b/crates/phosphor-app/src/settings.rs
@@ -2,10 +2,11 @@ use serde::{Deserialize, Serialize};
 
 use crate::ui::theme::ThemeMode;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum ParticleQuality {
     Low,
     Medium,
+    #[default]
     High,
     Ultra,
     Max,
@@ -38,12 +39,6 @@ impl ParticleQuality {
             Self::Ultra => 2.0,
             Self::Max => 4.0,
         }
-    }
-}
-
-impl Default for ParticleQuality {
-    fn default() -> Self {
-        Self::High
     }
 }
 

--- a/crates/phosphor-app/src/ui/panels/effect_panel.rs
+++ b/crates/phosphor-app/src/ui/panels/effect_panel.rs
@@ -387,7 +387,7 @@ fn draw_effect_grid(
                     } else {
                         &effect.description
                     };
-                    let mut text = base.to_string();
+                    let mut text = base.clone();
                     if let Some(s) = &particle_suffix {
                         text.push_str(s);
                     }

--- a/crates/phosphor-app/src/ui/panels/mod.rs
+++ b/crates/phosphor-app/src/ui/panels/mod.rs
@@ -452,12 +452,11 @@ pub fn draw_panels(
 
                     // Particle section (shows when active layer has particles)
                     if let Some(ref pinfo) = particle_info {
-                        let particle_badge = (if pinfo.alive_count >= 1000 {
+                        let particle_badge = if pinfo.alive_count >= 1000 {
                             format!("{:.1}K", pinfo.alive_count as f32 / 1000.0)
                         } else {
                             format!("{}", pinfo.alive_count)
-                        })
-                        .to_string();
+                        };
                         widgets::section(
                             ui,
                             "sec_particles",

--- a/crates/phosphor-app/src/ui/panels/preset_panel.rs
+++ b/crates/phosphor-app/src/ui/panels/preset_panel.rs
@@ -612,7 +612,7 @@ fn draw_preset_grid(
                 let hover_text = if is_armed {
                     "Right-click again to DELETE".to_string()
                 } else if is_builtin_section {
-                    pname.to_string()
+                    pname.clone()
                 } else if is_current && store.dirty {
                     format!("{pname} — click to reload, right-click to delete")
                 } else if is_current {

--- a/crates/phosphor-app/src/web/state.rs
+++ b/crates/phosphor-app/src/web/state.rs
@@ -315,13 +315,7 @@ fn build_params(store: &ParamStore) -> Vec<ParamInfo> {
                 }
                 ParamDef::Bool { name, .. } => {
                     let v = match value {
-                        Some(ParamValue::Bool(b)) => {
-                            if *b {
-                                1.0
-                            } else {
-                                0.0
-                            }
-                        }
+                        Some(ParamValue::Bool(b)) if *b => 1.0,
                         _ => 0.0,
                     };
                     ParamInfo {

--- a/patches/midir/src/backend/winmm/mod.rs
+++ b/patches/midir/src/backend/winmm/mod.rs
@@ -248,7 +248,7 @@ impl MidiInput {
             midiInOpen(
                 in_handle.as_mut_ptr(),
                 port_number as UINT,
-                handler::handle_input::<T> as DWORD_PTR,
+                handler::handle_input::<T> as *const () as DWORD_PTR,
                 handler_data_ptr as DWORD_PTR,
                 CALLBACK_FUNCTION,
             )


### PR DESCRIPTION
## Summary
Clears CI/lint warnings, adds a pre-commit hook to keep them from coming back, and tightens up the NDI docs.

- **Windows CI build warnings** — removed an unused import, allowed dead code on `wasapi_available()`, fixed an unreachable expression in `create_audio_fifo()`, and fixed a function-pointer cast in the midir patch.
- **Pre-commit hook** — added `.githooks/pre-commit` (runs `cargo fmt --check` + `cargo clippy -D warnings`) and documented setup in `CONTRIBUTING.md`. Also fixed import ordering.
- **Clippy cleanup** — cleared 13 default-feature clippy lints: collapsible match guards (`app.rs`, `main.rs`, `web/state.rs`), derivable `Default` for `ParticleQuality`, and redundant `String` clones in UI panels. All behavior-preserving (failed match guards fall through to existing catch-all arms).
- **NDI docs** — clarified that NDI output is built into official release downloads (only the NDI runtime needs installing); `--features ndi` is now framed as a from-source-only step in the README and TUTORIALS.

## Test plan
- `cargo fmt --all -- --check` — clean
- `cargo clippy -- -D warnings` — clean (matches the pre-commit hook)
- Docs changes reviewed for a download-user reading; only remaining `--features ndi` mentions are in source-build contexts.