### PR TITLE
Lint cfg-gated platform code cross-target (#1500)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -9,7 +9,9 @@ if ! cargo fmt --all -- --check 2>/dev/null; then
     exit 1
 fi
 
-# Check clippy (default features only — cross-platform gated code checked in CI)
+# Check clippy (host target, default features only — fast).
+# Windows/macOS cfg-gated code and non-default features are linted per-target in
+# CI's build matrix, not here. To lint platform code locally, see CONTRIBUTING.md.
 if ! cargo clippy -- -D warnings 2>/dev/null; then
     echo "ERROR: cargo clippy found warnings. Fix them before committing."
     exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,13 +51,13 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - name: Clippy
-        run: cargo clippy --all-targets
+        run: cargo clippy --all-targets -- -D warnings
       - name: Clippy (video feature)
-        run: cargo clippy --all-targets --features video
+        run: cargo clippy --all-targets --features video -- -D warnings
       - name: Clippy (webcam feature)
-        run: cargo clippy --all-targets --features webcam
+        run: cargo clippy --all-targets --features webcam -- -D warnings
       - name: Clippy (depth feature)
-        run: cargo clippy --all-targets --features depth
+        run: cargo clippy --all-targets --features depth -- -D warnings
 
   test:
     name: Test
@@ -104,9 +104,16 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+          components: clippy
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.os }}-${{ matrix.target }}-v2
+      # Clippy per native target so cfg-gated Windows/macOS code is actually linted
+      # (the host-only lint job and pre-commit hook never see it). See board #1500.
+      - name: Clippy (cross-target)
+        run: cargo clippy --target ${{ matrix.target }} -- -D warnings
+      - name: Clippy (all features)
+        run: cargo clippy --target ${{ matrix.target }} --features "video,webcam,ndi" -- -D warnings
       - name: Build
         run: cargo build --target ${{ matrix.target }}
       - name: Build (video feature)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.0
         with:
           components: rustfmt
       - run: cargo fmt --all -- --check
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install system deps
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev libudev-dev libclang-dev
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.0
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install system deps
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev libudev-dev libclang-dev
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.0
       - uses: Swatinem/rust-cache@v2
       - name: Test
         run: cargo test
@@ -101,7 +101,7 @@ jobs:
       - name: Install system deps (Linux)
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev libudev-dev libclang-dev
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.0
         with:
           targets: ${{ matrix.target }}
           components: clippy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libasound2-dev libudev-dev libclang-dev
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.0
         with:
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@
 - **README** — expanded build-from-source section with per-feature prerequisites; added Binding Matrix section and `B` keyboard shortcut
 - **NDI docs** — clarified that NDI output is built into official release downloads (only the NDI runtime needs installing); the `--features ndi` flag now framed as a from-source-only step in README and TUTORIALS
 
+### Documentation
+- **Stale-docs sweep** — corrected the `AudioFeatures` doc comment (45 → 46 features) and renamed the byte-size test to match its 184-byte assertion; fixed the audio-panel footer to report the real multi-resolution FFT sizes (`4096/1024/512` rather than a bare `512`)
+
 ## v1.7.1 — 2026-03-12
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,14 @@
 - **Clippy warnings** — cleared 13 default-feature clippy lints (collapsible match guards in `app.rs`/`main.rs`/`web/state.rs`, derivable `Default` for `ParticleQuality`, redundant `String` clones in UI panels)
 - **Depth feature** — `depth` feature now depends on `webcam` (depth estimation requires webcam input), eliminating dead-code warnings when building with `--features depth` alone
 - **Windows CI warnings** — removed unused import, allowed dead code on `wasapi_available()`, fixed unreachable expression in `create_audio_fifo()`, fixed function pointer cast in midir patch
+- **Cross-target clippy debt** — fixed a Windows-only `ptr_as_ptr`/`ptr_cast_constness` violation in `wasapi_capture.rs` and a `webcam`/`depth`-feature `implicit_clone` in `webcam.rs`, both previously invisible to the host-only clippy runs (board #1500)
 
 ### Added
 - **Pre-commit hook** — `.githooks/pre-commit` runs `cargo fmt --check` and `cargo clippy -D warnings`
 - **Reduced-motion detection (macOS/Windows)** — implemented the platform detection that was previously stubbed to always return `false`: macOS via `NSWorkspace.accessibilityDisplayShouldReduceMotion` (objc2-app-kit), Windows via `SystemParametersInfoW(SPI_GETCLIENTAREAANIMATION)`. Linux (gsettings) already worked. This is the detection backend only — `ReducedMotion` is not yet consumed by any effect/animation, so there is no user-visible behavior change until it is wired in
 
 ### Changed
+- **CI lints cfg-gated platform code** — the cross-OS `build` matrix now runs `cargo clippy -D warnings` per native target (Linux/macOS/Windows), so `#[cfg(target_os = …)]` code that host-only clippy never compiled is finally linted; the Linux `lint` job now denies warnings too (matching the pre-commit hook). The pre-commit hook stays host-only for fast commits — see CONTRIBUTING.md for the manual cross-target command. (board #1500)
 - **README** — expanded build-from-source section with per-feature prerequisites; added Binding Matrix section and `B` keyboard shortcut
 - **NDI docs** — clarified that NDI output is built into official release downloads (only the NDI runtime needs installing); the `--features ndi` flag now framed as a from-source-only step in README and TUTORIALS
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### Added
 - **Pre-commit hook** — `.githooks/pre-commit` runs `cargo fmt --check` and `cargo clippy -D warnings`
+- **Reduced-motion detection (macOS/Windows)** — implemented the platform detection that was previously stubbed to always return `false`: macOS via `NSWorkspace.accessibilityDisplayShouldReduceMotion` (objc2-app-kit), Windows via `SystemParametersInfoW(SPI_GETCLIENTAREAANIMATION)`. Linux (gsettings) already worked. This is the detection backend only — `ReducedMotion` is not yet consumed by any effect/animation, so there is no user-visible behavior change until it is wired in
 
 ### Changed
 - **README** — expanded build-from-source section with per-feature prerequisites; added Binding Matrix section and `B` keyboard shortcut

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,16 @@ Please include:
 - No new `unsafe` without justification
 - Prefer dedicated wgpu abstractions over raw API calls
 
+The pre-commit hook and the CI `lint` job run clippy on the **host** target only, so
+`#[cfg(target_os = "…")]` code for other platforms is not linted locally. CI's `build`
+matrix runs clippy per native target to cover it. If you touch Windows/macOS-gated code,
+lint it yourself by cross-compiling clippy (targets install via `rustup target add`):
+
+```sh
+cargo clippy --target x86_64-pc-windows-gnu -- -D warnings   # Windows-gated code
+cargo clippy --target aarch64-apple-darwin  -- -D warnings   # macOS-gated code
+```
+
 ## Pull Requests
 
 - One feature or fix per PR

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3274,6 +3274,7 @@ dependencies = [
  "nokhwa",
  "notify",
  "notify-debouncer-mini",
+ "objc2-app-kit 0.3.2",
  "ort",
  "pollster",
  "rfd",

--- a/crates/phosphor-app/Cargo.toml
+++ b/crates/phosphor-app/Cargo.toml
@@ -87,6 +87,16 @@ windows = { version = "0.61", features = [
     "Win32_System_Variant",
     "Win32_Devices_FunctionDiscovery",
     "Win32_UI_Shell_PropertiesSystem",
+    # SystemParametersInfoW / SPI_GETCLIENTAREAANIMATION (reduced-motion detection)
+    "Win32_UI_WindowsAndMessaging",
+] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+# NSWorkspace.accessibilityDisplayShouldReduceMotion (reduced-motion detection).
+# The accessor lives in the NSAccessibility module gated on its own feature.
+objc2-app-kit = { version = "0.3", default-features = false, features = [
+    "NSWorkspace",
+    "NSAccessibility",
 ] }
 
 [dev-dependencies]

--- a/crates/phosphor-app/src/audio/features.rs
+++ b/crates/phosphor-app/src/audio/features.rs
@@ -1,6 +1,6 @@
 use bytemuck::{Pod, Zeroable};
 
-/// 45 audio features, all normalized to 0.0-1.0 range.
+/// 46 audio features, all normalized to 0.0-1.0 range.
 /// Multi-resolution FFT bands + spectral shape + beat detection + MFCC + chroma.
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Pod, Zeroable)]
@@ -101,7 +101,7 @@ mod tests {
     }
 
     #[test]
-    fn size_is_180_bytes() {
+    fn size_is_184_bytes() {
         assert_eq!(std::mem::size_of::<AudioFeatures>(), 184);
     }
 }

--- a/crates/phosphor-app/src/audio/wasapi_capture.rs
+++ b/crates/phosphor-app/src/audio/wasapi_capture.rs
@@ -107,7 +107,9 @@ fn query_device_info() -> Result<(String, u32, u16, u16, u16)> {
 
         log::info!("WASAPI loopback: {name} ({sr}Hz, {ch}ch, {bps}bit, block_align={ba})");
 
-        CoTaskMemFree(Some(mix_format_ptr as *const _ as *const _));
+        CoTaskMemFree(Some(
+            mix_format_ptr.cast::<core::ffi::c_void>().cast_const(),
+        ));
         Ok((name, sr, ch, bps, ba))
     }
 }

--- a/crates/phosphor-app/src/media/webcam.rs
+++ b/crates/phosphor-app/src/media/webcam.rs
@@ -170,7 +170,7 @@ pub fn list_devices() -> Result<Vec<(u32, String)>, String> {
             CameraIndex::Index(i) => *i,
             CameraIndex::String(_) => 0,
         };
-        let name = info.human_name().to_string();
+        let name = info.human_name().clone();
         seen.entry(name)
             .and_modify(|existing| *existing = (*existing).min(idx))
             .or_insert(idx);

--- a/crates/phosphor-app/src/media/webcam_ffmpeg.rs
+++ b/crates/phosphor-app/src/media/webcam_ffmpeg.rs
@@ -403,13 +403,16 @@ fn spawn_ffmpeg(format_flag: &str, input: &str, size: &str) -> Result<Child, Str
 }
 
 /// Parse ffmpeg device list output. Platform-specific parsing.
+// `Result` is kept for parity with `list_devices()` (which can fail to spawn
+// ffmpeg); this parser itself never errors.
 #[cfg(not(target_os = "linux"))]
+#[allow(clippy::unnecessary_wraps)]
 fn parse_device_list(stderr: &str) -> Result<Vec<(u32, String)>, String> {
     let mut devices = Vec::new();
-    let mut idx = 0u32;
 
     #[cfg(target_os = "windows")]
     {
+        let mut idx = 0u32;
         // Parse dshow output: lines like [dshow @ ...] "Device Name" (video)
         for line in stderr.lines() {
             if line.contains("(video)") {

--- a/crates/phosphor-app/src/ui/accessibility/motion.rs
+++ b/crates/phosphor-app/src/ui/accessibility/motion.rs
@@ -37,14 +37,34 @@ fn detect_system_preference() -> bool {
 
 #[cfg(target_os = "macos")]
 fn detect_system_preference() -> bool {
-    // NSWorkspace.accessibilityDisplayShouldReduceMotion
-    false // TODO: implement via objc
+    use objc2_app_kit::NSWorkspace;
+    // `sharedWorkspace` returns the process-wide NSWorkspace singleton;
+    // `accessibilityDisplayShouldReduceMotion` reads a Bool property (both are
+    // safe in objc2-app-kit — no ownership transfer or threading requirements).
+    NSWorkspace::sharedWorkspace().accessibilityDisplayShouldReduceMotion()
 }
 
 #[cfg(target_os = "windows")]
 fn detect_system_preference() -> bool {
-    // SPI_GETCLIENTAREAANIMATION
-    false // TODO: implement via winapi
+    use windows::Win32::UI::WindowsAndMessaging::{
+        SPI_GETCLIENTAREAANIMATION, SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS, SystemParametersInfoW,
+    };
+    // SPI_GETCLIENTAREAANIMATION writes a BOOL (as i32): nonzero when client-area
+    // animations are enabled. Reduce motion when they are disabled.
+    let mut animations_enabled: i32 = 1;
+    let pv = std::ptr::from_mut(&mut animations_enabled).cast::<core::ffi::c_void>();
+    // SAFETY: FFI call into user32. `pvParam` points to a single i32 we own, which
+    // matches the BOOL this action writes. `fWinIni` is unused for read actions.
+    let ok = unsafe {
+        SystemParametersInfoW(
+            SPI_GETCLIENTAREAANIMATION,
+            0,
+            Some(pv),
+            SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS(0),
+        )
+    };
+    // On query failure, default to not reducing motion.
+    ok.is_ok() && animations_enabled == 0
 }
 
 #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]

--- a/crates/phosphor-app/src/ui/panels/audio_panel.rs
+++ b/crates/phosphor-app/src/ui/panels/audio_panel.rs
@@ -234,7 +234,7 @@ fn draw_bpm_ring(ui: &mut Ui, uniforms: &ShaderUniforms) -> egui::Response {
     let phase = uniforms.beat_phase;
 
     // Dim background ring
-    painter.circle_stroke(center, r, Stroke::new(2.0, tc.widget_bg));
+    painter.circle_stroke(center, r, Stroke::new(2.0_f32, tc.widget_bg));
 
     if bpm > 1.0 {
         // Arc: generate points from -PI/2 clockwise by phase * TAU
@@ -248,7 +248,7 @@ fn draw_bpm_ring(ui: &mut Ui, uniforms: &ShaderUniforms) -> egui::Response {
                     pos2(center.x + r * angle.cos(), center.y + r * angle.sin())
                 })
                 .collect();
-            painter.add(Shape::line(points, Stroke::new(2.5, tc.accent)));
+            painter.add(Shape::line(points, Stroke::new(2.5_f32, tc.accent)));
         }
 
         // Orbiting dot at current phase
@@ -339,7 +339,7 @@ fn draw_spectrum_bars(ui: &mut Ui, bands: &[f32; 7]) {
         let y = rect.bottom() - height * frac;
         painter.line_segment(
             [pos2(rect.left(), y), pos2(rect.right(), y)],
-            Stroke::new(0.5, grid_color),
+            Stroke::new(0.5_f32, grid_color),
         );
     }
 
@@ -377,7 +377,7 @@ fn draw_spectrum_bars(ui: &mut Ui, bands: &[f32; 7]) {
         if peaks[i] > 0.01 {
             painter.line_segment(
                 [pos2(x, peak_y), pos2(x + bar_width, peak_y)],
-                Stroke::new(1.0, color),
+                Stroke::new(1.0_f32, color),
             );
         }
     }

--- a/crates/phosphor-app/src/ui/panels/audio_panel.rs
+++ b/crates/phosphor-app/src/ui/panels/audio_panel.rs
@@ -636,7 +636,7 @@ fn draw_footer(ui: &mut Ui) {
     ui.add_space(4.0);
     ui.separator();
     ui.label(
-        RichText::new("7 bands · 7 dynamics · 12 chroma · 13 mfcc · 512 fft")
+        RichText::new("7 bands · 7 dynamics · 12 chroma · 13 mfcc · 4096/1024/512 fft")
             .size(7.0)
             .color(tc.text_secondary),
     );

--- a/crates/phosphor-app/src/ui/panels/binding_matrix.rs
+++ b/crates/phosphor-app/src/ui/panels/binding_matrix.rs
@@ -683,7 +683,7 @@ fn draw_source_group(
         3.0,
         bg,
         Stroke::new(
-            1.0,
+            1.0_f32,
             if hovered {
                 tc.card_border
             } else {
@@ -1016,7 +1016,7 @@ fn draw_target_column(
                         3.0,
                         bg,
                         Stroke::new(
-                            1.0,
+                            1.0_f32,
                             if hovered {
                                 tc.card_border
                             } else {
@@ -1266,7 +1266,7 @@ fn draw_center_column(
                 6.0,
                 btn_fill,
                 Stroke::new(
-                    1.0,
+                    1.0_f32,
                     if btn_resp.hovered() {
                         tc.card_border
                     } else {
@@ -1425,7 +1425,7 @@ fn draw_binding_card(
     let frame = egui::Frame::new()
         .fill(Color32::TRANSPARENT)
         .corner_radius(6.0)
-        .stroke(Stroke::new(1.0, border_color))
+        .stroke(Stroke::new(1.0_f32, border_color))
         .inner_margin(egui::Margin::ZERO);
 
     // Paint card background before frame content
@@ -1454,11 +1454,14 @@ fn draw_binding_card(
                 ui.painter().circle_stroke(
                     dot_rect.center(),
                     4.0,
-                    Stroke::new(1.0, src_rgba(src_color, 100)),
+                    Stroke::new(1.0_f32, src_rgba(src_color, 100)),
                 );
             } else {
-                ui.painter()
-                    .circle_stroke(dot_rect.center(), 3.5, Stroke::new(1.0, tc.text_dim));
+                ui.painter().circle_stroke(
+                    dot_rect.center(),
+                    3.5,
+                    Stroke::new(1.0_f32, tc.text_dim),
+                );
             }
             if dot_resp.clicked() {
                 if let Some(b) = bus.get_binding_mut(id) {
@@ -1560,7 +1563,7 @@ fn draw_binding_card(
                     pos2(sep_rect.min.x + 10.0, sep_y),
                     pos2(sep_rect.max.x - 10.0, sep_y),
                 ],
-                Stroke::new(1.0, src_rgba(src_color, 32)),
+                Stroke::new(1.0_f32, src_rgba(src_color, 32)),
             );
 
             ui.add_space(4.0);
@@ -2466,9 +2469,9 @@ fn draw_connections(ctx: &Context, state: &BindingMatrixState, bus: &BindingBus)
 
         let src_color = source_color(&binding.source);
         let (stroke_width, alpha) = if binding.enabled {
-            (1.5, 0.6_f32)
+            (1.5_f32, 0.6_f32)
         } else {
-            (1.0, 0.12)
+            (1.0_f32, 0.12)
         };
 
         let stroke_color = if binding.enabled {

--- a/crates/phosphor-app/src/ui/panels/effect_panel.rs
+++ b/crates/phosphor-app/src/ui/panels/effect_panel.rs
@@ -164,7 +164,7 @@ pub fn draw_effect_panel(ui: &mut Ui, loader: &EffectLoader) {
                     tc.text_secondary
                 }))
                 .fill(tc.card_bg)
-                .stroke(Stroke::new(1.0, tc.card_border))
+                .stroke(Stroke::new(1.0_f32, tc.card_border))
                 .corner_radius(CornerRadius::same(4)),
             )
             .on_hover_text("Copy to a new editable effect")
@@ -184,7 +184,7 @@ pub fn draw_effect_panel(ui: &mut Ui, loader: &EffectLoader) {
                     tc.text_secondary
                 }))
                 .fill(tc.card_bg)
-                .stroke(Stroke::new(1.0, tc.card_border))
+                .stroke(Stroke::new(1.0_f32, tc.card_border))
                 .corner_radius(CornerRadius::same(4)),
             )
             .on_hover_text("Open effect in editor")
@@ -202,7 +202,7 @@ pub fn draw_effect_panel(ui: &mut Ui, loader: &EffectLoader) {
                         .color(tc.text_primary),
                 )
                 .fill(tc.card_bg)
-                .stroke(Stroke::new(1.0, tc.card_border))
+                .stroke(Stroke::new(1.0_f32, tc.card_border))
                 .corner_radius(CornerRadius::same(4)),
             )
             .on_hover_text("Create a new effect from template")
@@ -296,7 +296,7 @@ fn draw_effect_grid(
                     (
                         tc.card_bg,
                         tc.text_primary,
-                        Stroke::new(1.0, tc.card_border),
+                        Stroke::new(1.0_f32, tc.card_border),
                     )
                 };
 

--- a/crates/phosphor-app/src/ui/panels/layer_panel.rs
+++ b/crates/phosphor-app/src/ui/panels/layer_panel.rs
@@ -62,7 +62,7 @@ fn drag_handle(ui: &mut Ui, color: Color32) -> egui::Response {
     let painter = ui.painter();
     let cx = rect.center().x;
     let cy = rect.center().y;
-    let stroke = Stroke::new(1.2, c);
+    let stroke = Stroke::new(1.2_f32, c);
     for dy in [-3.0_f32, 0.0, 3.0] {
         painter.line_segment(
             [egui::pos2(cx - 3.5, cy + dy), egui::pos2(cx + 3.5, cy + dy)],
@@ -82,7 +82,7 @@ fn lock_button(ui: &mut Ui, id: &str, locked: bool, color: Color32) -> egui::Res
     icon_button(ui, id, color, |painter, rect, c| {
         let cx = rect.center().x;
         let cy = rect.center().y;
-        let stroke = Stroke::new(1.2, c);
+        let stroke = Stroke::new(1.2_f32, c);
         // Body (rectangle)
         let body = Rect::from_center_size(egui::pos2(cx, cy + 1.5), Vec2::new(8.0, 6.0));
         if locked {
@@ -147,7 +147,7 @@ fn pin_button(ui: &mut Ui, id: &str, pinned: bool, color: Color32) -> egui::Resp
     icon_button(ui, id, color, |painter, rect, c| {
         let cx = rect.center().x;
         let cy = rect.center().y;
-        let stroke = Stroke::new(1.2, c);
+        let stroke = Stroke::new(1.2_f32, c);
         if pinned {
             painter.circle_filled(egui::pos2(cx, cy - 2.0), 3.5, c);
         } else {
@@ -259,9 +259,9 @@ pub fn draw_layer_panel(ui: &mut Ui, layers: &[LayerInfo], active_layer: usize) 
             let outer_stroke = {
                 let base_color = if is_active { tc.accent } else { tc.card_border };
                 if alpha < 1.0 {
-                    Stroke::new(1.0, with_alpha(base_color, alpha))
+                    Stroke::new(1.0_f32, with_alpha(base_color, alpha))
                 } else {
-                    Stroke::new(1.0, base_color)
+                    Stroke::new(1.0_f32, base_color)
                 }
             };
 
@@ -605,7 +605,7 @@ pub fn draw_layer_panel(ui: &mut Ui, layers: &[LayerInfo], active_layer: usize) 
                                             ui.painter().circle_stroke(
                                                 center,
                                                 radius,
-                                                Stroke::new(1.0, color),
+                                                Stroke::new(1.0_f32, color),
                                             );
                                             ui.painter().text(
                                                 center,
@@ -731,7 +731,7 @@ pub fn draw_layer_panel(ui: &mut Ui, layers: &[LayerInfo], active_layer: usize) 
                 } else {
                     ctrl_color
                 };
-                let stroke = Stroke::new(1.5, del_color);
+                let stroke = Stroke::new(1.5_f32, del_color);
                 ui.painter().line_segment(
                     [
                         egui::pos2(center.x - s, center.y - s),
@@ -787,7 +787,7 @@ pub fn draw_layer_panel(ui: &mut Ui, layers: &[LayerInfo], active_layer: usize) 
                 // Line
                 painter.line_segment(
                     [egui::pos2(left, line_y), egui::pos2(right, line_y)],
-                    Stroke::new(2.5, tc.accent),
+                    Stroke::new(2.5_f32, tc.accent),
                 );
                 // Endpoint dots
                 painter.circle_filled(egui::pos2(left, line_y), 3.0, tc.accent);
@@ -847,7 +847,7 @@ pub fn draw_layer_panel(ui: &mut Ui, layers: &[LayerInfo], active_layer: usize) 
             can_add,
             egui::Button::new(RichText::new(label).size(SMALL_SIZE).color(text_color))
                 .fill(fill)
-                .stroke(Stroke::new(1.0, stroke_color))
+                .stroke(Stroke::new(1.0_f32, stroke_color))
                 .corner_radius(CornerRadius::same(4))
                 .min_size(Vec2::new(width, MIN_INTERACT_HEIGHT)),
         )

--- a/crates/phosphor-app/src/ui/panels/obstacle_panel.rs
+++ b/crates/phosphor-app/src/ui/panels/obstacle_panel.rs
@@ -169,7 +169,7 @@ pub fn draw_obstacle_panel(ui: &mut Ui, info: &ObstacleInfo) {
                 tc.widget_bg
             })
             .stroke(egui::Stroke::new(
-                1.0,
+                1.0_f32,
                 if is_active {
                     egui::Color32::from_rgba_unmultiplied(0x3b, 0x82, 0xf6, 100)
                 } else {

--- a/crates/phosphor-app/src/ui/panels/osc_panel.rs
+++ b/crates/phosphor-app/src/ui/panels/osc_panel.rs
@@ -53,7 +53,7 @@ pub fn draw_osc_panel(ui: &mut Ui, osc: &mut OscSystem) {
     // TX settings in a subtle framed container (matches JSX)
     egui::Frame {
         fill: Color32::from_white_alpha(2),
-        stroke: egui::Stroke::new(1.0, Color32::from_white_alpha(13)),
+        stroke: egui::Stroke::new(1.0_f32, Color32::from_white_alpha(13)),
         corner_radius: egui::CornerRadius::same(4),
         inner_margin: egui::Margin::symmetric(8, 6),
         ..Default::default()

--- a/crates/phosphor-app/src/ui/panels/preset_panel.rs
+++ b/crates/phosphor-app/src/ui/panels/preset_panel.rs
@@ -67,7 +67,7 @@ pub fn draw_preset_section(ui: &mut Ui, store: &PresetStore) {
         let pulse = ((time * std::f64::consts::TAU / 1.6).sin() * 0.5 + 0.5) as f32;
         let alpha = (pulse * 0.35 + 0.15) * 255.0; // 15%–50%
         frame.stroke = Stroke::new(
-            1.0,
+            1.0_f32,
             Color32::from_rgba_unmultiplied(AMBER.r(), AMBER.g(), AMBER.b(), alpha as u8),
         );
     }
@@ -158,7 +158,7 @@ fn draw_preset_panel(ui: &mut Ui, store: &PresetStore) {
                 Frame {
                     fill: Color32::from_rgba_unmultiplied(AMBER.r(), AMBER.g(), AMBER.b(), 26), // ~10%
                     stroke: Stroke::new(
-                        1.0,
+                        1.0_f32,
                         Color32::from_rgba_unmultiplied(AMBER.r(), AMBER.g(), AMBER.b(), 77), // ~30%
                     ),
                     corner_radius: CornerRadius::same(4),
@@ -183,7 +183,7 @@ fn draw_preset_panel(ui: &mut Ui, store: &PresetStore) {
                                 )
                                 .fill(Color32::from_rgba_unmultiplied(255, 255, 255, 13)) // ~5%
                                 .stroke(Stroke::new(
-                                    1.0,
+                                    1.0_f32,
                                     Color32::from_rgba_unmultiplied(255, 255, 255, 31), // ~12%
                                 ))
                                 .corner_radius(CornerRadius::same(3)),
@@ -212,7 +212,7 @@ fn draw_preset_panel(ui: &mut Ui, store: &PresetStore) {
                                         64, // ~25%
                                     ))
                                     .stroke(Stroke::new(
-                                        1.0,
+                                        1.0_f32,
                                         Color32::from_rgba_unmultiplied(
                                             AMBER.r(),
                                             AMBER.g(),
@@ -409,7 +409,7 @@ fn draw_preset_panel(ui: &mut Ui, store: &PresetStore) {
                             .color(tc.text_primary),
                     )
                     .fill(tc.card_bg)
-                    .stroke(Stroke::new(1.0, tc.card_border))
+                    .stroke(Stroke::new(1.0_f32, tc.card_border))
                     .corner_radius(CornerRadius::same(4)),
                 )
                 .on_hover_text("Copy built-in to a new editable user preset")
@@ -444,7 +444,7 @@ fn draw_preset_panel(ui: &mut Ui, store: &PresetStore) {
             .add(
                 egui::Button::new(RichText::new(label).size(SMALL_SIZE).color(tc.text_primary))
                     .fill(fill)
-                    .stroke(Stroke::new(1.0, stroke_color))
+                    .stroke(Stroke::new(1.0_f32, stroke_color))
                     .corner_radius(CornerRadius::same(4)),
             )
             .on_hover_text("Clear all layers and start fresh")
@@ -506,7 +506,7 @@ fn draw_preset_grid(
                         tc.card_bg,
                         tc.accent,
                         Stroke::new(
-                            2.0,
+                            2.0_f32,
                             Color32::from_rgba_unmultiplied(
                                 tc.accent.r(),
                                 tc.accent.g(),
@@ -521,7 +521,7 @@ fn draw_preset_grid(
                         Color32::from_rgba_unmultiplied(AMBER.r(), AMBER.g(), AMBER.b(), 46), // ~18%
                         AMBER_TEXT,
                         Stroke::new(
-                            1.0,
+                            1.0_f32,
                             Color32::from_rgba_unmultiplied(
                                 AMBER.r(),
                                 AMBER.g(),
@@ -541,7 +541,7 @@ fn draw_preset_grid(
                         ),
                         Color32::from_rgba_unmultiplied(255, 255, 255, 242), // near-white
                         Stroke::new(
-                            1.0,
+                            1.0_f32,
                             Color32::from_rgba_unmultiplied(
                                 tc.accent.r(),
                                 tc.accent.g(),
@@ -554,7 +554,7 @@ fn draw_preset_grid(
                     (
                         tc.card_bg,
                         tc.text_primary,
-                        Stroke::new(1.0, tc.card_border),
+                        Stroke::new(1.0_f32, tc.card_border),
                     )
                 };
 

--- a/crates/phosphor-app/src/ui/panels/scene_panel.rs
+++ b/crates/phosphor-app/src/ui/panels/scene_panel.rs
@@ -189,7 +189,7 @@ pub fn draw_scene_panel(ui: &mut Ui, info: &SceneInfo) {
                         .strong(),
                 )
                 .fill(Color32::TRANSPARENT)
-                .stroke(Stroke::new(1.0, tc.success))
+                .stroke(Stroke::new(1.0_f32, tc.success))
                 .corner_radius(CornerRadius::same(WIDGET_ROUNDING));
                 if ui
                     .add_sized(
@@ -208,7 +208,7 @@ pub fn draw_scene_panel(ui: &mut Ui, info: &SceneInfo) {
                     let stop_btn =
                         egui::Button::new(RichText::new("STOP").size(SMALL_SIZE).color(tc.error))
                             .fill(Color32::TRANSPARENT)
-                            .stroke(Stroke::new(1.0, tc.error))
+                            .stroke(Stroke::new(1.0_f32, tc.error))
                             .corner_radius(CornerRadius::same(WIDGET_ROUNDING));
                     if ui
                         .add_sized(Vec2::new(60.0, MIN_INTERACT_HEIGHT), stop_btn)
@@ -225,7 +225,7 @@ pub fn draw_scene_panel(ui: &mut Ui, info: &SceneInfo) {
                             .color(tc.text_primary),
                     )
                     .fill(Color32::TRANSPARENT)
-                    .stroke(Stroke::new(1.0, tc.card_border))
+                    .stroke(Stroke::new(1.0_f32, tc.card_border))
                     .corner_radius(CornerRadius::same(WIDGET_ROUNDING));
                     if ui
                         .add_sized(Vec2::new(50.0, MIN_INTERACT_HEIGHT), prev_btn)
@@ -342,7 +342,7 @@ pub fn draw_scene_panel(ui: &mut Ui, info: &SceneInfo) {
         if info.cue_list.is_empty() {
             egui::Frame::new()
                 .fill(tc.card_bg)
-                .stroke(Stroke::new(1.0, tc.card_border))
+                .stroke(Stroke::new(1.0_f32, tc.card_border))
                 .corner_radius(CornerRadius::same(WIDGET_ROUNDING))
                 .inner_margin(egui::Margin::symmetric(6, 4))
                 .show(ui, |ui| {
@@ -421,7 +421,7 @@ pub fn draw_scene_panel(ui: &mut Ui, info: &SceneInfo) {
                 let add_btn =
                     egui::Button::new(RichText::new("+ Cue").size(SMALL_SIZE).color(tc.accent))
                         .fill(Color32::TRANSPARENT)
-                        .stroke(Stroke::new(1.0, tc.card_border))
+                        .stroke(Stroke::new(1.0_f32, tc.card_border))
                         .corner_radius(CornerRadius::same(WIDGET_ROUNDING))
                         .min_size(Vec2::new(btn_width, MIN_INTERACT_HEIGHT));
                 if ui.add(add_btn).clicked() {
@@ -463,9 +463,9 @@ fn draw_scene_tile(
         tc.card_bg
     };
     let border = if is_current {
-        Stroke::new(1.0, tc.accent)
+        Stroke::new(1.0_f32, tc.accent)
     } else {
-        Stroke::new(1.0, tc.card_border)
+        Stroke::new(1.0_f32, tc.card_border)
     };
 
     let frame_resp = egui::Frame::new()
@@ -564,7 +564,7 @@ fn draw_cue_row(
     };
     let border_color = if is_current {
         Stroke::new(
-            1.0,
+            1.0_f32,
             Color32::from_rgba_unmultiplied(
                 tc.accent.r(),
                 tc.accent.g(),
@@ -574,11 +574,11 @@ fn draw_cue_row(
         )
     } else if is_target {
         Stroke::new(
-            1.0,
+            1.0_f32,
             Color32::from_rgba_unmultiplied(tc.accent.r(), tc.accent.g(), tc.accent.b(), 40),
         )
     } else {
-        Stroke::new(1.0, tc.card_border)
+        Stroke::new(1.0_f32, tc.card_border)
     };
 
     let frame_resp = egui::Frame::new()
@@ -669,7 +669,7 @@ fn draw_cue_row(
                             .color(trans_color),
                     )
                     .fill(Color32::TRANSPARENT)
-                    .stroke(Stroke::new(1.0, trans_color))
+                    .stroke(Stroke::new(1.0_f32, trans_color))
                     .corner_radius(CornerRadius::same(WIDGET_ROUNDING));
                     if ui
                         .add_sized(Vec2::new(48.0, MIN_INTERACT_HEIGHT), trans_btn)

--- a/crates/phosphor-app/src/ui/panels/shader_editor.rs
+++ b/crates/phosphor-app/src/ui/panels/shader_editor.rs
@@ -152,7 +152,7 @@ fn close_icon(ui: &mut egui::Ui, id: &str, color: Color32) -> egui::Response {
     icon_button(ui, id, color, |painter, rect, c| {
         let center = rect.center();
         let s = 3.5;
-        let stroke = Stroke::new(1.5, c);
+        let stroke = Stroke::new(1.5_f32, c);
         painter.line_segment(
             [
                 egui::pos2(center.x - s, center.y - s),
@@ -174,7 +174,7 @@ fn minimize_icon(ui: &mut egui::Ui, id: &str, color: Color32) -> egui::Response 
     icon_button(ui, id, color, |painter, rect, c| {
         let center = rect.center();
         let s = 4.0;
-        let stroke = Stroke::new(1.5, c);
+        let stroke = Stroke::new(1.5_f32, c);
         let y = center.y + 3.0;
         painter.line_segment(
             [egui::pos2(center.x - s, y), egui::pos2(center.x + s, y)],
@@ -187,7 +187,7 @@ fn restore_icon(ui: &mut egui::Ui, id: &str, color: Color32) -> egui::Response {
     icon_button(ui, id, color, |painter, rect, c| {
         let center = rect.center();
         let s = 4.0;
-        let stroke = Stroke::new(1.5, c);
+        let stroke = Stroke::new(1.5_f32, c);
         let r = Rect::from_center_size(center, Vec2::splat(s * 2.0));
         painter.rect_stroke(r, 1.0, stroke, StrokeKind::Outside);
     })
@@ -331,7 +331,7 @@ pub fn draw_shader_editor(
             Frame {
                 fill: tc.panel,
                 inner_margin: Margin::same(0),
-                stroke: Stroke::new(1.0, tc.card_border),
+                stroke: Stroke::new(1.0_f32, tc.card_border),
                 corner_radius: CornerRadius {
                     nw: 8,
                     ne: 8,
@@ -378,7 +378,7 @@ pub fn draw_shader_editor(
                                 Color32::TRANSPARENT
                             })
                             .stroke(if shader_active {
-                                Stroke::new(1.0, tc.accent)
+                                Stroke::new(1.0_f32, tc.accent)
                             } else {
                                 Stroke::NONE
                             })
@@ -409,7 +409,7 @@ pub fn draw_shader_editor(
                                 Color32::TRANSPARENT
                             })
                             .stroke(if pfx_active {
-                                Stroke::new(1.0, tc.accent)
+                                Stroke::new(1.0_f32, tc.accent)
                             } else {
                                 Stroke::NONE
                             })
@@ -478,7 +478,7 @@ pub fn draw_shader_editor(
                             },
                         ))
                         .fill(tc.card_bg)
-                        .stroke(Stroke::new(1.0, tc.card_border))
+                        .stroke(Stroke::new(1.0_f32, tc.card_border))
                         .corner_radius(CornerRadius::same(3)),
                     );
                     if save_btn.clicked() {
@@ -525,7 +525,7 @@ pub fn draw_shader_editor(
             Frame {
                 fill: code_bg,
                 inner_margin: Margin::same(0),
-                stroke: Stroke::new(1.0, tc.card_border),
+                stroke: Stroke::new(1.0_f32, tc.card_border),
                 corner_radius: CornerRadius {
                     nw: 0,
                     ne: 0,

--- a/crates/phosphor-app/src/ui/panels/timeline_bar.rs
+++ b/crates/phosphor-app/src/ui/panels/timeline_bar.rs
@@ -66,7 +66,7 @@ pub fn draw_timeline_bar(ui: &mut Ui, timeline: &TimelineInfo, cue_names: &[Stri
             // Draw border — green for current cue
             let border_color = if is_current && transition_state.is_none() {
                 egui::Stroke::new(
-                    1.0,
+                    1.0_f32,
                     Color32::from_rgba_unmultiplied(
                         tc.accent.r(),
                         tc.accent.g(),
@@ -75,7 +75,7 @@ pub fn draw_timeline_bar(ui: &mut Ui, timeline: &TimelineInfo, cue_names: &[Stri
                     ),
                 )
             } else {
-                egui::Stroke::new(1.0, tc.card_border)
+                egui::Stroke::new(1.0_f32, tc.card_border)
             };
             painter.rect_stroke(
                 rect,
@@ -209,7 +209,7 @@ pub fn draw_timeline_bar(ui: &mut Ui, timeline: &TimelineInfo, cue_names: &[Stri
                     TransitionType::Cut => tc.accent,
                 };
                 ui.painter()
-                    .line_segment([top, bottom], egui::Stroke::new(2.0, playhead_color));
+                    .line_segment([top, bottom], egui::Stroke::new(2.0_f32, playhead_color));
             }
             TimelineInfoState::Holding { elapsed, hold_secs } => {
                 let cue_x = timeline.current_cue as f32 * block_width;
@@ -222,7 +222,7 @@ pub fn draw_timeline_bar(ui: &mut Ui, timeline: &TimelineInfo, cue_names: &[Stri
                 let top = egui::pos2(playhead_x, base_y);
                 let bottom = egui::pos2(playhead_x, base_y + bar_height);
                 ui.painter()
-                    .line_segment([top, bottom], egui::Stroke::new(2.0, tc.accent));
+                    .line_segment([top, bottom], egui::Stroke::new(2.0_f32, tc.accent));
             }
             _ => {}
         }

--- a/crates/phosphor-app/src/ui/theme/dark.rs
+++ b/crates/phosphor-app/src/ui/theme/dark.rs
@@ -12,35 +12,35 @@ pub fn dark_visuals() -> Visuals {
 
     v.override_text_color = Some(DARK_TEXT_PRIMARY);
     v.selection.bg_fill = DARK_ACCENT.gamma_multiply(0.4);
-    v.selection.stroke = Stroke::new(1.0, DARK_ACCENT);
+    v.selection.stroke = Stroke::new(1.0_f32, DARK_ACCENT);
 
     v.widgets.noninteractive.bg_fill = CARD_BG;
-    v.widgets.noninteractive.fg_stroke = Stroke::new(1.0, DARK_TEXT_SECONDARY);
+    v.widgets.noninteractive.fg_stroke = Stroke::new(1.0_f32, DARK_TEXT_SECONDARY);
     v.widgets.noninteractive.corner_radius = CornerRadius::same(WIDGET_ROUNDING);
-    v.widgets.noninteractive.bg_stroke = Stroke::new(0.5, CARD_BORDER);
+    v.widgets.noninteractive.bg_stroke = Stroke::new(0.5_f32, CARD_BORDER);
 
     v.widgets.inactive.bg_fill = DARK_WIDGET_BG;
-    v.widgets.inactive.fg_stroke = Stroke::new(1.0, DARK_TEXT_PRIMARY);
+    v.widgets.inactive.fg_stroke = Stroke::new(1.0_f32, DARK_TEXT_PRIMARY);
     v.widgets.inactive.corner_radius = CornerRadius::same(WIDGET_ROUNDING);
-    v.widgets.inactive.bg_stroke = Stroke::new(0.5, CARD_BORDER);
+    v.widgets.inactive.bg_stroke = Stroke::new(0.5_f32, CARD_BORDER);
 
     v.widgets.hovered.bg_fill = DARK_WIDGET_BG_HOVER;
-    v.widgets.hovered.fg_stroke = Stroke::new(1.0, DARK_TEXT_PRIMARY);
+    v.widgets.hovered.fg_stroke = Stroke::new(1.0_f32, DARK_TEXT_PRIMARY);
     v.widgets.hovered.corner_radius = CornerRadius::same(WIDGET_ROUNDING);
-    v.widgets.hovered.bg_stroke = Stroke::new(1.0, DARK_ACCENT);
+    v.widgets.hovered.bg_stroke = Stroke::new(1.0_f32, DARK_ACCENT);
 
     v.widgets.active.bg_fill = DARK_WIDGET_BG_ACTIVE;
-    v.widgets.active.fg_stroke = Stroke::new(1.0, DARK_TEXT_PRIMARY);
+    v.widgets.active.fg_stroke = Stroke::new(1.0_f32, DARK_TEXT_PRIMARY);
     v.widgets.active.corner_radius = CornerRadius::same(WIDGET_ROUNDING);
-    v.widgets.active.bg_stroke = Stroke::new(1.0, DARK_ACCENT);
+    v.widgets.active.bg_stroke = Stroke::new(1.0_f32, DARK_ACCENT);
 
     v.widgets.open.bg_fill = DARK_WIDGET_BG_ACTIVE;
-    v.widgets.open.fg_stroke = Stroke::new(1.0, DARK_TEXT_PRIMARY);
+    v.widgets.open.fg_stroke = Stroke::new(1.0_f32, DARK_TEXT_PRIMARY);
     v.widgets.open.corner_radius = CornerRadius::same(WIDGET_ROUNDING);
-    v.widgets.open.bg_stroke = Stroke::new(1.0, DARK_ACCENT);
+    v.widgets.open.bg_stroke = Stroke::new(1.0_f32, DARK_ACCENT);
 
     v.window_corner_radius = CornerRadius::same(PANEL_ROUNDING);
-    v.window_stroke = Stroke::new(1.0, CARD_BORDER);
+    v.window_stroke = Stroke::new(1.0_f32, CARD_BORDER);
 
     v
 }

--- a/crates/phosphor-app/src/ui/theme/light.rs
+++ b/crates/phosphor-app/src/ui/theme/light.rs
@@ -12,35 +12,35 @@ pub fn light_visuals() -> Visuals {
 
     v.override_text_color = Some(LIGHT_TEXT_PRIMARY);
     v.selection.bg_fill = LIGHT_ACCENT.gamma_multiply(0.2);
-    v.selection.stroke = Stroke::new(1.0, LIGHT_ACCENT);
+    v.selection.stroke = Stroke::new(1.0_f32, LIGHT_ACCENT);
 
     v.widgets.noninteractive.bg_fill = LIGHT_PANEL;
-    v.widgets.noninteractive.fg_stroke = Stroke::new(1.0, LIGHT_TEXT_SECONDARY);
+    v.widgets.noninteractive.fg_stroke = Stroke::new(1.0_f32, LIGHT_TEXT_SECONDARY);
     v.widgets.noninteractive.corner_radius = CornerRadius::same(WIDGET_ROUNDING);
-    v.widgets.noninteractive.bg_stroke = Stroke::new(0.5, LIGHT_SEPARATOR);
+    v.widgets.noninteractive.bg_stroke = Stroke::new(0.5_f32, LIGHT_SEPARATOR);
 
     v.widgets.inactive.bg_fill = LIGHT_WIDGET_BG;
-    v.widgets.inactive.fg_stroke = Stroke::new(1.0, LIGHT_TEXT_PRIMARY);
+    v.widgets.inactive.fg_stroke = Stroke::new(1.0_f32, LIGHT_TEXT_PRIMARY);
     v.widgets.inactive.corner_radius = CornerRadius::same(WIDGET_ROUNDING);
-    v.widgets.inactive.bg_stroke = Stroke::new(0.5, LIGHT_SEPARATOR);
+    v.widgets.inactive.bg_stroke = Stroke::new(0.5_f32, LIGHT_SEPARATOR);
 
     v.widgets.hovered.bg_fill = LIGHT_WIDGET_BG_HOVER;
-    v.widgets.hovered.fg_stroke = Stroke::new(1.0, LIGHT_TEXT_PRIMARY);
+    v.widgets.hovered.fg_stroke = Stroke::new(1.0_f32, LIGHT_TEXT_PRIMARY);
     v.widgets.hovered.corner_radius = CornerRadius::same(WIDGET_ROUNDING);
-    v.widgets.hovered.bg_stroke = Stroke::new(1.0, LIGHT_ACCENT);
+    v.widgets.hovered.bg_stroke = Stroke::new(1.0_f32, LIGHT_ACCENT);
 
     v.widgets.active.bg_fill = LIGHT_WIDGET_BG_ACTIVE;
-    v.widgets.active.fg_stroke = Stroke::new(1.0, LIGHT_TEXT_PRIMARY);
+    v.widgets.active.fg_stroke = Stroke::new(1.0_f32, LIGHT_TEXT_PRIMARY);
     v.widgets.active.corner_radius = CornerRadius::same(WIDGET_ROUNDING);
-    v.widgets.active.bg_stroke = Stroke::new(1.0, LIGHT_ACCENT);
+    v.widgets.active.bg_stroke = Stroke::new(1.0_f32, LIGHT_ACCENT);
 
     v.widgets.open.bg_fill = LIGHT_WIDGET_BG_ACTIVE;
-    v.widgets.open.fg_stroke = Stroke::new(1.0, LIGHT_TEXT_PRIMARY);
+    v.widgets.open.fg_stroke = Stroke::new(1.0_f32, LIGHT_TEXT_PRIMARY);
     v.widgets.open.corner_radius = CornerRadius::same(WIDGET_ROUNDING);
-    v.widgets.open.bg_stroke = Stroke::new(1.0, LIGHT_ACCENT);
+    v.widgets.open.bg_stroke = Stroke::new(1.0_f32, LIGHT_ACCENT);
 
     v.window_corner_radius = CornerRadius::same(PANEL_ROUNDING);
-    v.window_stroke = Stroke::new(1.0, LIGHT_SEPARATOR);
+    v.window_stroke = Stroke::new(1.0_f32, LIGHT_SEPARATOR);
 
     v
 }

--- a/crates/phosphor-app/src/ui/theme/mod.rs
+++ b/crates/phosphor-app/src/ui/theme/mod.rs
@@ -83,25 +83,25 @@ fn midnight_visuals() -> Visuals {
     v.extreme_bg_color = Color32::from_rgb(0x08, 0x0C, 0x14);
 
     v.widgets.noninteractive.bg_fill = Color32::from_rgb(0x14, 0x1A, 0x28);
-    v.widgets.noninteractive.fg_stroke = Stroke::new(1.0, Color32::from_rgb(0xB0, 0xC0, 0xD0));
-    v.widgets.noninteractive.bg_stroke = Stroke::new(1.0, Color32::from_rgb(0x2A, 0x38, 0x50));
+    v.widgets.noninteractive.fg_stroke = Stroke::new(1.0_f32, Color32::from_rgb(0xB0, 0xC0, 0xD0));
+    v.widgets.noninteractive.bg_stroke = Stroke::new(1.0_f32, Color32::from_rgb(0x2A, 0x38, 0x50));
 
     v.widgets.inactive.bg_fill = Color32::from_rgb(0x1A, 0x24, 0x36);
-    v.widgets.inactive.fg_stroke = Stroke::new(1.0, Color32::from_rgb(0xC0, 0xD0, 0xE0));
-    v.widgets.inactive.bg_stroke = Stroke::new(1.0, Color32::from_rgb(0x30, 0x40, 0x58));
+    v.widgets.inactive.fg_stroke = Stroke::new(1.0_f32, Color32::from_rgb(0xC0, 0xD0, 0xE0));
+    v.widgets.inactive.bg_stroke = Stroke::new(1.0_f32, Color32::from_rgb(0x30, 0x40, 0x58));
 
     v.widgets.hovered.bg_fill = Color32::from_rgb(0x22, 0x30, 0x48);
-    v.widgets.hovered.fg_stroke = Stroke::new(1.5, Color32::from_rgb(0xD0, 0xE0, 0xF0));
-    v.widgets.hovered.bg_stroke = Stroke::new(1.5, Color32::from_rgb(0x50, 0x90, 0xD0));
+    v.widgets.hovered.fg_stroke = Stroke::new(1.5_f32, Color32::from_rgb(0xD0, 0xE0, 0xF0));
+    v.widgets.hovered.bg_stroke = Stroke::new(1.5_f32, Color32::from_rgb(0x50, 0x90, 0xD0));
 
     v.widgets.active.bg_fill = Color32::from_rgb(0x28, 0x3A, 0x54);
-    v.widgets.active.fg_stroke = Stroke::new(1.5, Color32::from_rgb(0xE0, 0xF0, 0xFF));
-    v.widgets.active.bg_stroke = Stroke::new(2.0, Color32::from_rgb(0x50, 0x90, 0xD0));
+    v.widgets.active.fg_stroke = Stroke::new(1.5_f32, Color32::from_rgb(0xE0, 0xF0, 0xFF));
+    v.widgets.active.bg_stroke = Stroke::new(2.0_f32, Color32::from_rgb(0x50, 0x90, 0xD0));
 
     v.selection.bg_fill = Color32::from_rgb(0x50, 0x90, 0xD0).gamma_multiply(0.4);
-    v.selection.stroke = Stroke::new(1.5, Color32::from_rgb(0x50, 0x90, 0xD0));
+    v.selection.stroke = Stroke::new(1.5_f32, Color32::from_rgb(0x50, 0x90, 0xD0));
 
-    v.window_stroke = Stroke::new(1.0, Color32::from_rgb(0x2A, 0x38, 0x50));
+    v.window_stroke = Stroke::new(1.0_f32, Color32::from_rgb(0x2A, 0x38, 0x50));
 
     v
 }
@@ -117,25 +117,25 @@ fn ember_visuals() -> Visuals {
     v.extreme_bg_color = Color32::from_rgb(0x10, 0x0C, 0x08);
 
     v.widgets.noninteractive.bg_fill = Color32::from_rgb(0x24, 0x1C, 0x16);
-    v.widgets.noninteractive.fg_stroke = Stroke::new(1.0, Color32::from_rgb(0xD0, 0xC0, 0xB0));
-    v.widgets.noninteractive.bg_stroke = Stroke::new(1.0, Color32::from_rgb(0x40, 0x30, 0x20));
+    v.widgets.noninteractive.fg_stroke = Stroke::new(1.0_f32, Color32::from_rgb(0xD0, 0xC0, 0xB0));
+    v.widgets.noninteractive.bg_stroke = Stroke::new(1.0_f32, Color32::from_rgb(0x40, 0x30, 0x20));
 
     v.widgets.inactive.bg_fill = Color32::from_rgb(0x2C, 0x22, 0x1A);
-    v.widgets.inactive.fg_stroke = Stroke::new(1.0, Color32::from_rgb(0xE0, 0xD0, 0xC0));
-    v.widgets.inactive.bg_stroke = Stroke::new(1.0, Color32::from_rgb(0x50, 0x38, 0x28));
+    v.widgets.inactive.fg_stroke = Stroke::new(1.0_f32, Color32::from_rgb(0xE0, 0xD0, 0xC0));
+    v.widgets.inactive.bg_stroke = Stroke::new(1.0_f32, Color32::from_rgb(0x50, 0x38, 0x28));
 
     v.widgets.hovered.bg_fill = Color32::from_rgb(0x38, 0x2A, 0x20);
-    v.widgets.hovered.fg_stroke = Stroke::new(1.5, Color32::from_rgb(0xF0, 0xE0, 0xD0));
-    v.widgets.hovered.bg_stroke = Stroke::new(1.5, Color32::from_rgb(0xE0, 0x90, 0x30));
+    v.widgets.hovered.fg_stroke = Stroke::new(1.5_f32, Color32::from_rgb(0xF0, 0xE0, 0xD0));
+    v.widgets.hovered.bg_stroke = Stroke::new(1.5_f32, Color32::from_rgb(0xE0, 0x90, 0x30));
 
     v.widgets.active.bg_fill = Color32::from_rgb(0x44, 0x30, 0x22);
-    v.widgets.active.fg_stroke = Stroke::new(1.5, Color32::from_rgb(0xFF, 0xF0, 0xE0));
-    v.widgets.active.bg_stroke = Stroke::new(2.0, Color32::from_rgb(0xE0, 0x90, 0x30));
+    v.widgets.active.fg_stroke = Stroke::new(1.5_f32, Color32::from_rgb(0xFF, 0xF0, 0xE0));
+    v.widgets.active.bg_stroke = Stroke::new(2.0_f32, Color32::from_rgb(0xE0, 0x90, 0x30));
 
     v.selection.bg_fill = Color32::from_rgb(0xE0, 0x90, 0x30).gamma_multiply(0.4);
-    v.selection.stroke = Stroke::new(1.5, Color32::from_rgb(0xE0, 0x90, 0x30));
+    v.selection.stroke = Stroke::new(1.5_f32, Color32::from_rgb(0xE0, 0x90, 0x30));
 
-    v.window_stroke = Stroke::new(1.0, Color32::from_rgb(0x40, 0x30, 0x20));
+    v.window_stroke = Stroke::new(1.0_f32, Color32::from_rgb(0x40, 0x30, 0x20));
 
     v
 }
@@ -151,25 +151,25 @@ fn neon_visuals() -> Visuals {
     v.extreme_bg_color = Color32::from_rgb(0x06, 0x04, 0x0C);
 
     v.widgets.noninteractive.bg_fill = Color32::from_rgb(0x14, 0x10, 0x20);
-    v.widgets.noninteractive.fg_stroke = Stroke::new(1.0, Color32::from_rgb(0xC0, 0xB0, 0xD0));
-    v.widgets.noninteractive.bg_stroke = Stroke::new(1.0, Color32::from_rgb(0x30, 0x20, 0x44));
+    v.widgets.noninteractive.fg_stroke = Stroke::new(1.0_f32, Color32::from_rgb(0xC0, 0xB0, 0xD0));
+    v.widgets.noninteractive.bg_stroke = Stroke::new(1.0_f32, Color32::from_rgb(0x30, 0x20, 0x44));
 
     v.widgets.inactive.bg_fill = Color32::from_rgb(0x1A, 0x14, 0x2A);
-    v.widgets.inactive.fg_stroke = Stroke::new(1.0, Color32::from_rgb(0xD0, 0xC0, 0xE0));
-    v.widgets.inactive.bg_stroke = Stroke::new(1.0, Color32::from_rgb(0x3A, 0x28, 0x50));
+    v.widgets.inactive.fg_stroke = Stroke::new(1.0_f32, Color32::from_rgb(0xD0, 0xC0, 0xE0));
+    v.widgets.inactive.bg_stroke = Stroke::new(1.0_f32, Color32::from_rgb(0x3A, 0x28, 0x50));
 
     v.widgets.hovered.bg_fill = Color32::from_rgb(0x24, 0x1C, 0x38);
-    v.widgets.hovered.fg_stroke = Stroke::new(1.5, Color32::from_rgb(0xE0, 0xD0, 0xF0));
-    v.widgets.hovered.bg_stroke = Stroke::new(1.5, Color32::from_rgb(0xFF, 0x50, 0xC0));
+    v.widgets.hovered.fg_stroke = Stroke::new(1.5_f32, Color32::from_rgb(0xE0, 0xD0, 0xF0));
+    v.widgets.hovered.bg_stroke = Stroke::new(1.5_f32, Color32::from_rgb(0xFF, 0x50, 0xC0));
 
     v.widgets.active.bg_fill = Color32::from_rgb(0x2C, 0x22, 0x44);
-    v.widgets.active.fg_stroke = Stroke::new(1.5, Color32::from_rgb(0xF0, 0xE0, 0xFF));
-    v.widgets.active.bg_stroke = Stroke::new(2.0, Color32::from_rgb(0xFF, 0x50, 0xC0));
+    v.widgets.active.fg_stroke = Stroke::new(1.5_f32, Color32::from_rgb(0xF0, 0xE0, 0xFF));
+    v.widgets.active.bg_stroke = Stroke::new(2.0_f32, Color32::from_rgb(0xFF, 0x50, 0xC0));
 
     v.selection.bg_fill = Color32::from_rgb(0xFF, 0x50, 0xC0).gamma_multiply(0.35);
-    v.selection.stroke = Stroke::new(1.5, Color32::from_rgb(0xFF, 0x50, 0xC0));
+    v.selection.stroke = Stroke::new(1.5_f32, Color32::from_rgb(0xFF, 0x50, 0xC0));
 
-    v.window_stroke = Stroke::new(1.0, Color32::from_rgb(0x30, 0x20, 0x44));
+    v.window_stroke = Stroke::new(1.0_f32, Color32::from_rgb(0x30, 0x20, 0x44));
 
     v
 }
@@ -186,25 +186,25 @@ fn high_contrast_visuals() -> Visuals {
     v.override_text_color = Some(Color32::WHITE);
 
     v.widgets.noninteractive.bg_fill = Color32::from_rgb(0x11, 0x11, 0x11);
-    v.widgets.noninteractive.fg_stroke = Stroke::new(1.0, Color32::from_rgb(0xCC, 0xCC, 0xCC));
-    v.widgets.noninteractive.bg_stroke = Stroke::new(1.0, Color32::from_rgb(0x66, 0x66, 0x66));
+    v.widgets.noninteractive.fg_stroke = Stroke::new(1.0_f32, Color32::from_rgb(0xCC, 0xCC, 0xCC));
+    v.widgets.noninteractive.bg_stroke = Stroke::new(1.0_f32, Color32::from_rgb(0x66, 0x66, 0x66));
 
     v.widgets.inactive.bg_fill = Color32::from_rgb(0x1A, 0x1A, 0x1A);
-    v.widgets.inactive.fg_stroke = Stroke::new(1.0, Color32::WHITE);
-    v.widgets.inactive.bg_stroke = Stroke::new(1.0, Color32::from_rgb(0x66, 0x66, 0x66));
+    v.widgets.inactive.fg_stroke = Stroke::new(1.0_f32, Color32::WHITE);
+    v.widgets.inactive.bg_stroke = Stroke::new(1.0_f32, Color32::from_rgb(0x66, 0x66, 0x66));
 
     v.widgets.hovered.bg_fill = Color32::from_rgb(0x28, 0x28, 0x28);
-    v.widgets.hovered.fg_stroke = Stroke::new(1.5, Color32::WHITE);
-    v.widgets.hovered.bg_stroke = Stroke::new(2.0, Color32::from_rgb(0x55, 0xAA, 0xFF));
+    v.widgets.hovered.fg_stroke = Stroke::new(1.5_f32, Color32::WHITE);
+    v.widgets.hovered.bg_stroke = Stroke::new(2.0_f32, Color32::from_rgb(0x55, 0xAA, 0xFF));
 
     v.widgets.active.bg_fill = Color32::from_rgb(0x33, 0x33, 0x33);
-    v.widgets.active.fg_stroke = Stroke::new(1.5, Color32::WHITE);
-    v.widgets.active.bg_stroke = Stroke::new(2.0, Color32::from_rgb(0x55, 0xAA, 0xFF));
+    v.widgets.active.fg_stroke = Stroke::new(1.5_f32, Color32::WHITE);
+    v.widgets.active.bg_stroke = Stroke::new(2.0_f32, Color32::from_rgb(0x55, 0xAA, 0xFF));
 
     v.selection.bg_fill = Color32::from_rgb(0x55, 0xAA, 0xFF).gamma_multiply(0.5);
-    v.selection.stroke = Stroke::new(2.0, Color32::from_rgb(0x55, 0xAA, 0xFF));
+    v.selection.stroke = Stroke::new(2.0_f32, Color32::from_rgb(0x55, 0xAA, 0xFF));
 
-    v.window_stroke = Stroke::new(2.0, Color32::from_rgb(0x66, 0x66, 0x66));
+    v.window_stroke = Stroke::new(2.0_f32, Color32::from_rgb(0x66, 0x66, 0x66));
 
     v
 }

--- a/crates/phosphor-app/src/ui/widgets.rs
+++ b/crates/phosphor-app/src/ui/widgets.rs
@@ -11,7 +11,7 @@ pub fn card_frame(ui: &Ui) -> Frame {
     let tc = theme_colors(ui.ctx());
     Frame {
         fill: tc.card_bg,
-        stroke: Stroke::new(1.0, tc.card_border),
+        stroke: Stroke::new(1.0_f32, tc.card_border),
         corner_radius: CornerRadius::same(CARD_ROUNDING),
         inner_margin: Margin::same(CARD_PADDING as i8),
         outer_margin: Margin::symmetric(0, CARD_MARGIN as i8),
@@ -226,7 +226,7 @@ pub fn draw_diagonal_stripes(
     spacing: f32,
 ) {
     let clipped = painter.with_clip_rect(rect);
-    let stroke = Stroke::new(1.5, color);
+    let stroke = Stroke::new(1.5_f32, color);
     let h = rect.height();
     let mut offset = -h;
     while offset < rect.width() {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,8 @@
+# Pinned so local dev and CI use the same rustc/clippy. Rolling `stable` plus the
+# `-D warnings` gate in CI breaks the build whenever a new release adds a lint,
+# with no code change — e.g. 1.97 activated `float_literal_f32_fallback`. Bump this
+# deliberately (and clear any new lints in the same change). CI's
+# dtolnay/rust-toolchain action is pinned to the same version.
+[toolchain]
+channel = "1.97.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Closes board **#1500**.

## Problem
CI and the pre-commit hook only ran `cargo clippy` on the host (Linux) target, so `#[cfg(target_os = "...")]` Windows/macOS code was **never linted**. This hid a real `ptr_as_ptr`/`ptr_cast_constness` violation in `wasapi_capture.rs` that only appears under a Windows-target clippy run.

## Changes
- **`wasapi_capture.rs`** — fix the pointer cast. Verified it *fails* then *passes* under `cargo clippy --target x86_64-pc-windows-gnu -- -D warnings`.
- **`ci.yml` build matrix** — run `cargo clippy -D warnings` per native target (default + `video,webcam,ndi`) with `components: clippy`, so cfg-gated code is finally linted on the native Windows/macOS runners.
- **`ci.yml` lint job** — now denies warnings (parity with the pre-commit hook). This surfaced + fixed a `webcam`/`depth`-feature `implicit_clone` in `webcam.rs`.
- **`.githooks/pre-commit`** — stays host-only for fast commits; corrected its misleading comment.
- **`CONTRIBUTING.md`** — documented the manual cross-target clippy command for contributors touching platform code.

## Verification (local)
- Windows + macOS target clippy (default + `video,ndi`) clean; host `--all-targets -D warnings` clean across all feature variants; `cargo fmt --check` clean; 408 tests pass.
- The `video,webcam,ndi` clippy step on Windows/macOS needs those runners' C toolchains — **that's what this PR's CI run confirms.**

_Note: board #1446 (X11 vsync) was investigated alongside this and closed as **not reproducible** — Fifo gates correctly on the test X11 setup and Symbiosis is now GPU-bound, so it's intentionally not part of this PR._